### PR TITLE
skip goddard screen if goddard isn't built

### DIFF
--- a/levels/intro/script.c
+++ b/levels/intro/script.c
@@ -45,6 +45,9 @@ const LevelScript level_intro_splash_screen[] = {
 
 const LevelScript level_intro_mario_head_regular[] = {
     INIT_LEVEL(),
+#ifndef GODDARD
+    EXIT_AND_EXECUTE(/*seg*/ 0x14, _menuSegmentRomStart, _menuSegmentRomEnd, level_main_menu_entry_1),
+#endif
     BLACKOUT(/*active*/ TRUE),
     FIXED_LOAD(/*loadAddr*/ _goddardSegmentStart, /*romStart*/ _goddardSegmentRomStart, /*romEnd*/ _goddardSegmentRomEnd),
 #ifdef GODDARD


### PR DESCRIPTION
if you don't enable GODDARD in the makefile, then the goddard screen is skipped entirely

get real btw: `This branch is 210 commits ahead of CrashOveride95:master. `