### PR TITLE
soundMode is u8 and uses bitfield

### DIFF
--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -58,7 +58,7 @@ struct MainMenuSaveData
     // the older the high score is. This is used for tie-breaking when displaying
     // on the high score screen.
     u32 coinScoreAges[NUM_SAVE_FILES];
-    u16 soundMode;
+    u8 soundMode: 2;
 
 #ifdef VERSION_EU
     u16 language;

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -61,7 +61,7 @@ struct MainMenuSaveData
     u8 soundMode: 2;
 
 #ifdef VERSION_EU
-    u16 language;
+    u8 language: 2;
 #define SUBTRAHEND 8
 #else
 #define SUBTRAHEND 6


### PR DESCRIPTION
Saves space in the savefile by making `soundMode` into a u8 an using a bitfield for it. Doesn't break old savefiles because it only touches menu data.