### PR TITLE
automatic padding for iQue builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,7 +765,13 @@ $(ELF): $(O_FILES) $(YAY0_OBJ_FILES) $(SEG_FILES) $(BUILD_DIR)/$(LD_SCRIPT) unde
 # Build ROM
 $(ROM): $(ELF)
 	$(call print,Building ROM:,$<,$@)
+ifeq      ($(CONSOLE),n64)
 	$(V)$(OBJCOPY) --pad-to=0x800000 --gap-fill=0xFF $< $@ -O binary
+else ifeq ($(CONSOLE),bb)
+	$(V)$(OBJCOPY) --gap-fill=0x00 $< $@ -O binary
+	$(V)dd if=$@ of=tmp bs=16K conv=sync
+	$(V)mv tmp $@
+endif
 	$(V)$(N64CKSUM) $@
 
 $(BUILD_DIR)/$(TARGET).objdump: $(ELF)


### PR DESCRIPTION
this pads iQue builds automatically so that the ROM size is a multiple of `0x4000` which is necessary for them to work

doesn't affect N64 builds

credit to Jhynjhiruu