### PR TITLE
Fix Ares by disabling instant input patch on it

### DIFF
--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -1,4 +1,5 @@
 #include <ultra64.h>
+#include <PR/os_internal_reg.h>
 
 #include "sm64.h"
 #include "gfx_dimensions.h"
@@ -41,6 +42,7 @@ OSContStatus gControllerStatuses[4];
 OSContPad gControllerPads[4];
 u8 gControllerBits;
 u8 gIsConsole;
+u8 gCacheEmulated = TRUE;
 u8 gBorderHeight;
 #ifdef EEP
 s8 gEepromProbe;
@@ -368,6 +370,21 @@ void draw_reset_bars(void) {
     osRecvMesg(&gGameVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
 }
 
+void check_cache_emulation() {
+    // Disable interrupts to ensure that nothing evicts the variable from cache while we're using it.
+    u32 saved = __osDisableInt();
+    // Create a variable with an initial value of 1. This value will remain cached.
+    volatile u8 sCachedValue = 1;
+    // Overwrite the variable directly in RDRAM without going through cache.
+    // This should preserve its value of 1 in dcache if dcache is emulated correctly.
+    *(u8*)(K0_TO_K1(&sCachedValue)) = 0;
+    // Read the variable back from dcache, if it's still 1 then cache is emulated correctly.
+    // If it's zero, then dcache is not emulated correctly.
+    gCacheEmulated = sCachedValue;
+    // Restore interrupts
+    __osRestoreInt(saved);
+}
+
 /**
  * Initial settings for the first rendered frame.
  */
@@ -389,8 +406,8 @@ void render_init(void) {
     end_master_display_list();
     exec_display_list(&gGfxPool->spTask);
 
-    // Skip incrementing the initial framebuffer index on emulators so that they display immediately as the Gfx task finishes
-    if ((*(volatile u32 *)0xA4100010) != 0) { // Read RDP Clock Register, has a value of zero on emulators
+    // Skip incrementing the initial framebuffer index on emulators other than Ares so that they display immediately as the Gfx task finishes
+    if (gIsConsole || gCacheEmulated) { // Read RDP Clock Register, has a value of zero on emulators
         sRenderingFramebuffer++;
     }
     gGlobalTimer++;
@@ -427,8 +444,8 @@ void display_and_vsync(void) {
     osViSwapBuffer((void *) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[sRenderedFramebuffer]));
     profiler_log_thread5_time(THREAD5_END);
     osRecvMesg(&gGameVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
-    // Skip swapping buffers on emulator so that they display immediately as the Gfx task finishes
-    if ((*(volatile u32 *)0xA4100010) != 0) { // Read RDP Clock Register, has a value of zero on emulators
+    // Skip swapping buffers on emulator other than Ares so that they display immediately as the Gfx task finishes
+    if (gIsConsole || gCacheEmulated) { // Read RDP Clock Register, has a value of zero on emulators
         if (++sRenderedFramebuffer == 3) {
             sRenderedFramebuffer = 0;
         }

--- a/src/game/game_init.h
+++ b/src/game/game_init.h
@@ -42,6 +42,7 @@ extern struct GfxPool *gGfxPool;
 extern u8 gControllerBits;
 extern u8 gIsConsole;
 extern u8 gBorderHeight;
+extern u8 gCacheEmulated;
 #ifdef EEP
 extern s8 gEepromProbe;
 #endif


### PR DESCRIPTION
Ares is incompatible with the instant input patch. Ares also happens to be the only emulator that emulates dcache accurately. So this checks for dcache emulation and disables the instant input patch if it passes. Fixes Ares. 