### PR TITLE
Various small improvements / fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -570,9 +570,11 @@ $(BUILD_DIR)/%.ci4.inc.c: %.ci4.png
 $(BUILD_DIR)/%.elf: $(BUILD_DIR)/%.o
 	$(call print,Linking ELF file:,$<,$@)
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map -o $@ $<
-# Override for leveldata.elf, which otherwise matches the above pattern
+# Override for leveldata.elf, which otherwise matches the above pattern.
+# Has to be a static pattern rule for make-4.4 and above to trigger the second
+# expansion.
 .SECONDEXPANSION:
-$(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o $(BUILD_DIR)/bin/$$(TEXTURE_BIN).elf
+$(LEVEL_ELF_FILES): $(BUILD_DIR)/levels/%/leveldata.elf: $(BUILD_DIR)/levels/%/leveldata.o $(BUILD_DIR)/bin/$$(TEXTURE_BIN).elf
 	$(call print,Linking ELF file:,$<,$@)
 	$(V)$(LD) -e 0 -Ttext=$(SEGMENT_ADDRESS) -Map $@.map --just-symbols=$(BUILD_DIR)/bin/$(TEXTURE_BIN).elf -o $@ $<
 

--- a/Makefile.split
+++ b/Makefile.split
@@ -39,6 +39,8 @@ ACTOR_GROUPS := \
 
 LEVEL_FILES := $(addsuffix leveldata,$(LEVEL_DIRS))
 
+LEVEL_ELF_FILES := $(foreach level_dir,$(LEVEL_DIRS),$(BUILD_DIR)/levels/$(level_dir)leveldata.elf)
+
 SEG_FILES := \
     $(SEGMENTS:%=$(BUILD_DIR)/bin/%.elf) \
     $(ACTOR_GROUPS:%=$(BUILD_DIR)/actors/%.elf) \

--- a/src/boot/rnc1.s
+++ b/src/boot/rnc1.s
@@ -412,4 +412,4 @@ make_huftable8:
 		jr	ra
 		nop					/*(Delay Slot) */
 
-		.end
+.end Propack_UnpackM1

--- a/src/boot/rnc2.s
+++ b/src/boot/rnc2.s
@@ -663,11 +663,11 @@ unpack11:
 			jr		ra
         nop
 
-	.data
+.end Propack_UnpackM2
+
+        .data
         .align 4
 
         .word    0,0,0,0,0,0,0,0,0,0,0,0
 mystack:
 	.word    0
-
-	.end

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -135,12 +135,7 @@ void init_rsp(void) {
 
     gSPNumLights(gDisplayListHead++, NUMLIGHTS_1);
     gSPTexture(gDisplayListHead++, 0, 0, 0, G_TX_RENDERTILE, G_OFF);
-
-    // @bug Failing to set the clip ratio will result in warped triangles in F3DEX2
-    // without this change: https://jrra.zone/n64/doc/n64man/gsp/gSPClipRatio.htm
-#ifdef F3DEX_GBI_2
-    gSPClipRatio(gDisplayListHead++, FRUSTRATIO_1);
-#endif
+    gSPClipRatio(gDisplayListHead++, FRUSTRATIO_2);
 }
 
 /**


### PR DESCRIPTION
* [Revert frustum ratio back to 2](https://github.com/CrashOveride95/ultrasm64/commit/4d6bb25501485cd264efafaf7382e42f934462d6)
* [Fix builds on Make 4.4](https://github.com/CrashOveride95/ultrasm64/commit/135a05a1624d718ae681e28699ff759443682d32)
* [remove warnings from rnc1/2 files](https://github.com/CrashOveride95/ultrasm64/commit/b6546e9b7d1eb3ab84c0d40fc15a2c91c49ddfa4)