### PR TITLE
Add support for building with MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,7 @@ endif
 
 $(BUILD_DIR)/%.table: %.aiff
 	$(call print,Extracting codebook:,$<,$@)
-	$(V)$(AIFF_EXTRACT_CODEBOOK) $< >$@
+	$(V)$(AIFF_EXTRACT_CODEBOOK) $< $@
 
 $(BUILD_DIR)/%.aifc: $(BUILD_DIR)/%.table %.aiff
 	$(call print,Encoding ADPCM:,$(word 2,$^),$@)

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
 
   # Make tools if out of date
   $(info Building tools...)
-  DUMMY != $(MAKE) -s -C $(TOOLS_DIR) >&2 || echo FAIL
+  DUMMY != "$(MAKE)" -s -C $(TOOLS_DIR) >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
       $(error Failed to build tools)
     endif
@@ -469,7 +469,7 @@ clean:
 
 distclean: clean
 	$(PYTHON) extract_assets.py --clean
-	$(MAKE) -C $(TOOLS_DIR) clean
+	"$(MAKE)" -C $(TOOLS_DIR) clean
 
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -155,9 +155,15 @@ def main():
             sys.exit(1)
 
     # Make sure tools exist
-    subprocess.check_call(
-        ["make", "-s", "-C", "tools/", "n64graphics", "skyconv", "mio0", "aifc_decode"]
-    )
+    tools = [ "n64graphics", "skyconv", "mio0", "aifc_decode" ]
+    if os.name == 'nt':
+        tools = [tool + ".exe" for tool in tools]
+        make = "mingw32-make"
+    else:
+        make = "make"
+
+    cmd = [make, "-s", "-C", "tools/"] + tools
+    subprocess.check_call(cmd)
 
     # Go through the assets in roughly alphabetical order (but assets in the same
     # mio0 file still go together).

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -49,13 +49,17 @@ def remove_file(fname):
 def clean_assets(local_asset_file):
     assets = set(read_asset_map().keys())
     assets.update(read_local_asset_list(local_asset_file))
-    for fname in list(assets) + [".assets-local.txt"]:
+    for fname in list(assets):
         if fname.startswith("@"):
             continue
         try:
             remove_file(fname)
         except FileNotFoundError:
             pass
+
+    if local_asset_file is not None:
+        local_asset_file.close()
+        remove_file(".assets-local.txt")
 
 
 def main():

--- a/sm64.ld
+++ b/sm64.ld
@@ -134,12 +134,12 @@ SECTIONS
       BUILD_DIR/src/hvqm*.o(.text);
       BUILD_DIR/src/audio*.o(.text);
 #if defined(ISVPRINT) || defined(UNF)
-      */libultra_d.a:*.o(.text);
+      *libultra_d.a:*.o(.text);
 #else
-      */libultra_rom.a:*.o(.text);
+      *libultra_rom.a:*.o(.text);
 #endif
       */libnustd.a:*.o(.text);
-      */libgcc.a:*.o(.text);
+      *libgcc.a:*.o(.text);
       */librtc.a:*.o(.text);
       */libz.a:*.o(.text);
       */libhvqm2.a:*.o(.text);
@@ -153,9 +153,9 @@ SECTIONS
       BUILD_DIR/src/boot*.o(.data*);
       BUILD_DIR/src/audio*.o(.data*);
 #if defined(ISVPRINT) || defined(UNF)
-      */libultra_d.a:*.o(.data*);
+      *libultra_d.a:*.o(.data*);
 #else
-      */libultra_rom.a:*.o(.data*);
+      *libultra_rom.a:*.o(.data*);
 #endif
       */libhvqm2.a:*.o(.data*);
       */librtc.a:*.o(.data*);
@@ -169,11 +169,11 @@ SECTIONS
       BUILD_DIR/src/boot*.o(.rodata*);
       BUILD_DIR/src/audio*.o(.rodata*);
 #if defined(ISVPRINT) || defined(UNF)
-      */libultra_d.a:*.o(.rodata*);
+      *libultra_d.a:*.o(.rodata*);
 #else
-      */libultra_rom.a:*.o(.rodata*);
+      *libultra_rom.a:*.o(.rodata*);
 #endif
-      */libgcc.a:*.o(.rodata*);
+      *libgcc.a:*.o(.rodata*);
       */librtc.a:*.o(.rodata*);
       */libz.a:*.o(.rodata*);
 
@@ -186,13 +186,13 @@ SECTIONS
       BUILD_DIR/src/hvqm*.o(.*bss*);
       BUILD_DIR/src/audio*.o(.*bss*);
 #if defined(ISVPRINT) || defined(UNF)
-      */libultra_d.a:*.o(COMMON);
-      */libultra_d.a:*.o(.scommon);
-      */libultra_d.a:*.o(.*bss*);
+      *libultra_d.a:*.o(COMMON);
+      *libultra_d.a:*.o(.scommon);
+      *libultra_d.a:*.o(.*bss*);
 #else
-      */libultra_rom.a:*.o(COMMON);
-      */libultra_rom.a:*.o(.scommon);
-      */libultra_rom.a:*.o(.*bss*);
+      *libultra_rom.a:*.o(COMMON);
+      *libultra_rom.a:*.o(.scommon);
+      *libultra_rom.a:*.o(.*bss*);
 #endif
       */libhvqm2.a:*.o(.bss*);
       */librtc.a:*.o(.bss*);

--- a/sm64.ld
+++ b/sm64.ld
@@ -140,7 +140,7 @@ SECTIONS
 #else
       *libultra_rom.a:*.o(.text);
 #endif
-      */libnustd.a:*.o(.text);
+      *libnustd.a:*.o(.text);
       *libgcc.a:*.o(.text);
       */librtc.a:*.o(.text);
       */libz.a:*.o(.text);

--- a/sm64.ld
+++ b/sm64.ld
@@ -71,6 +71,8 @@ OUTPUT_ARCH (mips)
    _##name##_mio0SegmentRomStart = _##name##_yay0SegmentRomStart; \
    _##name##_mio0SegmentRomEnd = _##name##_yay0SegmentRomEnd;
 
+#define LIBGODDARD_A BUILD_DIR[/\\]libgoddard.a
+
 SECTIONS
 {
    __romPos = 0;
@@ -300,32 +302,32 @@ SECTIONS
       BUILD_DIR/src/menu*.o(.data*);
       BUILD_DIR/src/menu*.o(.rodata*);
 #ifdef GODDARD
-      BUILD_DIR/libgoddard.a:*.o(.text);
+      LIBGODDARD_A:*.o(.text);
       /* goddard subsystem data */
-      BUILD_DIR/libgoddard.a:gd_main.o(.data*);
-      BUILD_DIR/libgoddard.a:draw_objects.o(.data*);
-      BUILD_DIR/libgoddard.a:objects.o(.data*);
-      BUILD_DIR/libgoddard.a:particles.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlist_proc.o(.data*);
-      BUILD_DIR/libgoddard.a:debug_utils.o(.data*);
-      BUILD_DIR/libgoddard.a:joints.o(.data*);
-      BUILD_DIR/libgoddard.a:shape_helper.o(.data*);
-      BUILD_DIR/libgoddard.a:renderer.o(.data*);
+      LIBGODDARD_A:gd_main.o(.data*);
+      LIBGODDARD_A:draw_objects.o(.data*);
+      LIBGODDARD_A:objects.o(.data*);
+      LIBGODDARD_A:particles.o(.data*);
+      LIBGODDARD_A:dynlist_proc.o(.data*);
+      LIBGODDARD_A:debug_utils.o(.data*);
+      LIBGODDARD_A:joints.o(.data*);
+      LIBGODDARD_A:shape_helper.o(.data*);
+      LIBGODDARD_A:renderer.o(.data*);
       /* goddard subsystem rodata */
-      BUILD_DIR/libgoddard.a:gd_main.o(.rodata*);
-      BUILD_DIR/libgoddard.a:gd_memory.o(.rodata*);
-      BUILD_DIR/libgoddard.a:draw_objects.o(.rodata*);
-      BUILD_DIR/libgoddard.a:objects.o(.rodata*);
-      BUILD_DIR/libgoddard.a:skin_movement.o(.rodata*);
-      BUILD_DIR/libgoddard.a:particles.o(.rodata*);
-      BUILD_DIR/libgoddard.a:dynlist_proc.o(.rodata*);
-      BUILD_DIR/libgoddard.a:old_menu.o(.rodata*);
-      BUILD_DIR/libgoddard.a:debug_utils.o(.rodata*);
-      BUILD_DIR/libgoddard.a:joints.o(.rodata*);
-      BUILD_DIR/libgoddard.a:skin.o(.rodata*);
-      BUILD_DIR/libgoddard.a:gd_math.o(.rodata*);
-      BUILD_DIR/libgoddard.a:shape_helper.o(.rodata*);
-      BUILD_DIR/libgoddard.a:renderer.o(.rodata*);
+      LIBGODDARD_A:gd_main.o(.rodata*);
+      LIBGODDARD_A:gd_memory.o(.rodata*);
+      LIBGODDARD_A:draw_objects.o(.rodata*);
+      LIBGODDARD_A:objects.o(.rodata*);
+      LIBGODDARD_A:skin_movement.o(.rodata*);
+      LIBGODDARD_A:particles.o(.rodata*);
+      LIBGODDARD_A:dynlist_proc.o(.rodata*);
+      LIBGODDARD_A:old_menu.o(.rodata*);
+      LIBGODDARD_A:debug_utils.o(.rodata*);
+      LIBGODDARD_A:joints.o(.rodata*);
+      LIBGODDARD_A:skin.o(.rodata*);
+      LIBGODDARD_A:gd_math.o(.rodata*);
+      LIBGODDARD_A:shape_helper.o(.rodata*);
+      LIBGODDARD_A:renderer.o(.rodata*);
 #endif
    }
    END_SEG(goddard)
@@ -333,7 +335,7 @@ SECTIONS
    {
       BUILD_DIR/src/menu*.o(.bss*);
 #ifdef GODDARD
-      BUILD_DIR/libgoddard.a:*.o(.bss*);
+      LIBGODDARD_A:*.o(.bss*);
 #endif
    }
    END_NOLOAD(goddard)
@@ -360,23 +362,23 @@ SECTIONS
 #ifdef GODDARD
    BEGIN_SEG(gd_dynlists, 0x04000000)
    {
-      BUILD_DIR/libgoddard.a:dynlist_test_cube.o(.data);
-      BUILD_DIR/libgoddard.a:dynlist_unused.o(.data);
-      BUILD_DIR/libgoddard.a:dynlist_mario_face.o(.data);
-      BUILD_DIR/libgoddard.a:dynlists_mario_eyes.o(.data);
-      BUILD_DIR/libgoddard.a:dynlists_mario_eyebrows_mustache.o(.data);
-      BUILD_DIR/libgoddard.a:dynlist_mario_master.o(.data);
-      BUILD_DIR/libgoddard.a:anim_mario_mustache_right.o(.data);
-      BUILD_DIR/libgoddard.a:anim_mario_mustache_left.o(.data);
-      BUILD_DIR/libgoddard.a:anim_mario_lips_1.o(.data);
-      BUILD_DIR/libgoddard.a:anim_mario_lips_2.o(.data);
-      BUILD_DIR/libgoddard.a:anim_mario_eyebrows_1.o(.data);
-      BUILD_DIR/libgoddard.a:anim_group_1.o(.data);
-      BUILD_DIR/libgoddard.a:anim_group_2.o(.data);
-      BUILD_DIR/libgoddard.a:dynlist_test_cube.o(.rodata*);
-      BUILD_DIR/libgoddard.a:dynlist_unused.o(.rodata*);
-      BUILD_DIR/libgoddard.a:*.o(.data);
-      BUILD_DIR/libgoddard.a:*.o(.rodata);
+      LIBGODDARD_A:dynlist_test_cube.o(.data);
+      LIBGODDARD_A:dynlist_unused.o(.data);
+      LIBGODDARD_A:dynlist_mario_face.o(.data);
+      LIBGODDARD_A:dynlists_mario_eyes.o(.data);
+      LIBGODDARD_A:dynlists_mario_eyebrows_mustache.o(.data);
+      LIBGODDARD_A:dynlist_mario_master.o(.data);
+      LIBGODDARD_A:anim_mario_mustache_right.o(.data);
+      LIBGODDARD_A:anim_mario_mustache_left.o(.data);
+      LIBGODDARD_A:anim_mario_lips_1.o(.data);
+      LIBGODDARD_A:anim_mario_lips_2.o(.data);
+      LIBGODDARD_A:anim_mario_eyebrows_1.o(.data);
+      LIBGODDARD_A:anim_group_1.o(.data);
+      LIBGODDARD_A:anim_group_2.o(.data);
+      LIBGODDARD_A:dynlist_test_cube.o(.rodata*);
+      LIBGODDARD_A:dynlist_unused.o(.rodata*);
+      LIBGODDARD_A:*.o(.data);
+      LIBGODDARD_A:*.o(.rodata);
    }
    END_SEG(gd_dynlists)
 #endif

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -9492,7 +9492,6 @@ BAD_RETURN(s32) cutscene_unlock_key_door(UNUSED struct Camera *c) {
 s32 intro_peach_move_camera_start_to_pipe(struct Camera *c, struct CutsceneSplinePoint positionSpline[],
                   struct CutsceneSplinePoint focusSpline[]) {
     Vec3f offset;
-    s32 posReturn = 0;
     s32 focusReturn = 0;
 
     /**
@@ -9500,7 +9499,7 @@ s32 intro_peach_move_camera_start_to_pipe(struct Camera *c, struct CutsceneSplin
      * updated. Otherwise position would move two frames ahead, and c->focus would always be one frame
      * further along the spline than c->pos.
      */
-    posReturn = move_point_along_spline(c->pos, positionSpline, &sCutsceneSplineSegment, &sCutsceneSplineSegmentProgress);
+    move_point_along_spline(c->pos, positionSpline, &sCutsceneSplineSegment, &sCutsceneSplineSegmentProgress);
     focusReturn = move_point_along_spline(c->focus, focusSpline, &sCutsceneSplineSegment, &sCutsceneSplineSegmentProgress);
 
     // The two splines used by this function are reflected in the horizontal plane for some reason,
@@ -9512,7 +9511,6 @@ s32 intro_peach_move_camera_start_to_pipe(struct Camera *c, struct CutsceneSplin
     vec3f_add(c->focus, offset);
     vec3f_add(c->pos, offset);
 
-    posReturn += focusReturn; // Unused
     return focusReturn;
 }
 

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -2684,7 +2684,7 @@ static s32 check_for_instant_quicksand(struct MarioState *m) {
 }
 
 s32 mario_execute_cutscene_action(struct MarioState *m) {
-    s32 cancel;
+    s32 cancel = FALSE;
 
     if (check_for_instant_quicksand(m)) {
         return TRUE;

--- a/src/goddard/dynlist_proc.c
+++ b/src/goddard/dynlist_proc.c
@@ -1896,47 +1896,6 @@ void d_set_att_offset(const struct GdVec3f *off) {
 }
 
 /**
- * An incorrectly-coded recursive function that was presumably supposed to
- * set the offset of an attached object. Now, it will only call itself
- * until it encounters a NULL pointer, which will trigger a `fatal_printf()`
- * call.
- *
- * @note Not called
- */
-void d_set_att_to_offset(UNUSED u32 a) {
-    struct GdObj *dynobj; // sp3c
-    UNUSED u8 filler[24];
-
-    if (sDynListCurObj == NULL) {
-        fatal_printf("proc_dynlist(): No current object");
-    }
-
-    dynobj = sDynListCurObj;
-    d_stash_dynobj();
-    switch (sDynListCurObj->type) {
-        case OBJ_TYPE_JOINTS:
-            set_cur_dynobj(((struct ObjJoint *) dynobj)->attachedToObj);
-            break;
-        case OBJ_TYPE_NETS:
-            set_cur_dynobj(((struct ObjNet *) dynobj)->attachedToObj);
-            break;
-        case OBJ_TYPE_PARTICLES:
-            set_cur_dynobj(((struct ObjParticle *) dynobj)->attachedToObj);
-            break;
-        default:
-            fatal_printf("%s: Object '%s'(%x) does not support this function.", "dSetAttToOffset()",
-                         sDynListCurInfo->name, sDynListCurObj->type);
-    }
-
-    if (sDynListCurObj == NULL) {
-        fatal_printf("dSetAttOffset(): Object '%s' isnt attached to anything",
-                     sStashedDynObjInfo->name);
-    }
-    d_set_att_to_offset(a);
-    d_unstash_dynobj();
-}
-
-/**
  * Store the offset of the attached object into `dst`.
  *
  * @note Not called

--- a/src/goddard/joints.c
+++ b/src/goddard/joints.c
@@ -664,7 +664,7 @@ void func_80190574(s32 a0, struct ObjJoint *a1, struct ObjJoint *a2, f32 x, f32 
     UNUSED u8 filler1[4];
     UNUSED u32 unused = 0;
     UNUSED u8 filler2[12]; // unused vec?
-    struct GdVec3f sp24C;
+    struct GdVec3f sp24C = { 0.0f, 0.0f, 0.0f };
     struct GdVec3f sp240;
     UNUSED u8 filler3[8];
     s32 sp234; // i?

--- a/src/goddard/old_menu.c
+++ b/src/goddard/old_menu.c
@@ -21,7 +21,7 @@
  */
 
 // bss
-static char sDefSettingsMenuStr[0x100];
+UNUSED static char sDefSettingsMenuStr[0x100];
 static struct GdVec3f sStaticVec;
 UNUSED static struct GdVec3f unusedVec;
 static struct ObjGadget *sCurGadgetPtr;

--- a/src/goddard/renderer.c
+++ b/src/goddard/renderer.c
@@ -149,7 +149,7 @@ static s32 sLightId;
 static Hilite sHilites[600];
 static struct GdVec3f D_801BD758;
 static struct GdVec3f D_801BD768; // had to migrate earlier
-static u32 D_801BD774;
+UNUSED static u32 D_801BD774;
 static struct GdObj *sMenuGadgets[9]; // @ 801BD778; d_obj ptr storage? menu?
 static struct ObjView *sDebugViews[2];  // Seems to be a list of ObjViews for displaying debug info
 static struct GdDisplayList *sStaticDl;     // @ 801BD7A8
@@ -167,7 +167,7 @@ static LookAt D_801BE7D0[3];
 static OSMesgQueue D_801BE830; // controller msg queue
 static OSMesg D_801BE848[10];
 UNUSED static u32 unref_801be870[16];
-static OSMesgQueue D_801BE8B0;
+UNUSED static OSMesgQueue D_801BE8B0;
 static OSMesgQueue sGdDMAQueue; // @ 801BE8C8
 UNUSED static u32 unref_801be8e0[25];
 static OSMesg sGdMesgBuf[1]; // @ 801BE944
@@ -201,7 +201,7 @@ static s32 D_801A86BC = 1;
 static s32 D_801A86C0 = 0; // gd_dl id for something?
 UNUSED static u32 unref_801a86C4 = 10;
 static s32 sMtxParamType = G_MTX_PROJECTION;
-static struct GdVec3f D_801A86CC = { 1.0f, 1.0f, 1.0f };
+UNUSED static struct GdVec3f D_801A86CC = { 1.0f, 1.0f, 1.0f };
 static struct ObjView *sActiveView = NULL;  // @ 801A86D8 current view? used when drawing dl
 static struct ObjView *sScreenView = NULL; // @ 801A86DC
 static struct ObjView *D_801A86E0 = NULL;

--- a/src/usb/debug.c
+++ b/src/usb/debug.c
@@ -608,7 +608,7 @@ https://github.com/buu342/N64-UNFLoader
             {
                 s32 bpoll;
                 #ifndef LIBDRAGON
-                    osPiReadIo(0xB80002F8, &bpoll);
+                    osPiReadIo(0xB80002F8, (u32 *)&bpoll);
                 #else
                     bpoll = io_read(0xB80002F8);
                 #endif
@@ -734,10 +734,12 @@ https://github.com/buu342/N64-UNFLoader
                                 dataleft = 0;
                             break;
                         }
+                        // fallthrough
                     case '@':
                         filestep++;
                         if (filestep < 3)
                             break;
+                        // fallthrough
                     default:
                         // Decide what to do based on the file handle
                         if (filestep == 0 && debug_command_incoming_start[tok] == -1)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -51,7 +51,10 @@ patch_elf_32bit_SOURCES := patch_elf_32bit.c
 
 aifc_decode_SOURCES := aifc_decode.c
 
-aiff_extract_codebook_SOURCES := aiff_extract_codebook.c
+aiff_extract_codebook: $(LIBAUDIOFILE)
+aiff_extract_codebook_SOURCES := aiff_extract_codebook.c sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c
+aiff_extract_codebook_CFLAGS  := -DEXTRACT_CODEBOOK -Iaudiofile -Wno-uninitialized
+aiff_extract_codebook_LDFLAGS := -Laudiofile -laudiofile -lstdc++
 
 tabledesign$(EXT): $(LIBAUDIOFILE)
 tabledesign_SOURCES := sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -51,7 +51,7 @@ patch_elf_32bit_SOURCES := patch_elf_32bit.c
 
 aifc_decode_SOURCES := aifc_decode.c
 
-aiff_extract_codebook: $(LIBAUDIOFILE)
+aiff_extract_codebook$(EXT): $(LIBAUDIOFILE)
 aiff_extract_codebook_SOURCES := aiff_extract_codebook.c sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c
 aiff_extract_codebook_CFLAGS  := -DEXTRACT_CODEBOOK -Iaudiofile -Wno-uninitialized
 aiff_extract_codebook_LDFLAGS := -Laudiofile -laudiofile -lstdc++
@@ -82,7 +82,7 @@ all: all-except-recomp
 
 clean:
 	$(RM) $(ALL_PROGRAMS)
-	$(MAKE) -C audiofile clean
+	"$(MAKE)" -C audiofile clean
 
 define COMPILE
 $(1)$$(EXT): $($1_SOURCES)
@@ -92,6 +92,6 @@ endef
 $(foreach p,$(BUILD_PROGRAMS),$(eval $(call COMPILE,$(p))))
 
 $(LIBAUDIOFILE):
-	@$(MAKE) -C audiofile
+	@"$(MAKE)" -C audiofile
 
 .PHONY: all all-except-recomp clean default

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,6 +10,14 @@ LDFLAGS      := -lm
 ALL_PROGRAMS := armips filesizer rncpack n64graphics n64graphics_ci mio0 slienc n64cksum textconv patch_elf_32bit aifc_decode aiff_extract_codebook vadpcm_enc tabledesign extract_data_for_mio skyconv
 LIBAUDIOFILE := audiofile/libaudiofile.a
 
+ifeq ($(OS),Windows_NT)
+  EXT := .exe
+  OUTPUTS := $(ALL_PROGRAMS:=.exe)
+else
+  EXT :=
+  OUTPUTS := $(ALL_PROGRAMS)
+endif
+
 # Only build armips from tools if it is not found on the system
 ifeq ($(call find-command,armips),)
   BUILD_PROGRAMS := $(ALL_PROGRAMS)
@@ -45,7 +53,7 @@ aifc_decode_SOURCES := aifc_decode.c
 
 aiff_extract_codebook_SOURCES := aiff_extract_codebook.c
 
-tabledesign: $(LIBAUDIOFILE)
+tabledesign$(EXT): $(LIBAUDIOFILE)
 tabledesign_SOURCES := sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c
 tabledesign_CFLAGS  := -Iaudiofile -Wno-uninitialized
 tabledesign_LDFLAGS := -Laudiofile -laudiofile -lstdc++
@@ -57,15 +65,15 @@ extract_data_for_mio_SOURCES := extract_data_for_mio.c
 
 skyconv_SOURCES := skyconv.c n64graphics.c utils.c
 
-armips: CC := $(CXX)
+armips$(EXT): CC := $(CXX)
 armips_SOURCES := armips.cpp
-armips_CFLAGS  := -std=c++11 -fno-exceptions -fno-rtti -pipe
+armips_CFLAGS  := -std=gnu++11 -fno-exceptions -fno-rtti -pipe
 armips_LDFLAGS := -pthread
 ifeq ($(HOST_ENV),MinGW)
   armips_LDFLAGS += -municode
 endif
 
-all-except-recomp: $(LIBAUDIOFILE) $(BUILD_PROGRAMS)
+all-except-recomp: $(LIBAUDIOFILE) $(OUTPUTS)
 
 all: all-except-recomp
 
@@ -74,8 +82,8 @@ clean:
 	$(MAKE) -C audiofile clean
 
 define COMPILE
-$(1): $($1_SOURCES)
-	$$(CC) $(CFLAGS) $($1_CFLAGS) $$^ -o $$@ $($1_LDFLAGS) $(LDFLAGS)
+$(1)$$(EXT): $($1_SOURCES)
+	$$(CC) $(CFLAGS) $($1_CFLAGS) $$^ -o $(1) $($1_LDFLAGS) $(LDFLAGS)
 endef
 
 $(foreach p,$(BUILD_PROGRAMS),$(eval $(call COMPILE,$(p))))

--- a/tools/armips.cpp
+++ b/tools/armips.cpp
@@ -15496,7 +15496,7 @@ int64_t fileSize(const std::wstring& fileName)
 {
 #ifdef _WIN32
 	WIN32_FILE_ATTRIBUTE_DATA attr;
-	if (!GetFileAttributesEx(fileName.c_str(),GetFileExInfoStandard,&attr)
+	if (!GetFileAttributesExW(fileName.c_str(),GetFileExInfoStandard,&attr)
 		|| (attr.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 		return 0;
 	return ((int64_t) attr.nFileSizeHigh << 32) | (int64_t) attr.nFileSizeLow;
@@ -15514,10 +15514,10 @@ bool fileExists(const std::wstring& strFilename)
 {
 #ifdef _WIN32
 #ifdef ARMIPS_WINDOWS_UWP
-	return GetFileAttributes(strFilename.c_str()) != INVALID_FILE_ATTRIBUTES;
+	return GetFileAttributesW(strFilename.c_str()) != INVALID_FILE_ATTRIBUTES;
 #else
 	int OldMode = SetErrorMode(SEM_FAILCRITICALERRORS);
-	bool success = GetFileAttributes(strFilename.c_str()) != INVALID_FILE_ATTRIBUTES;
+	bool success = GetFileAttributesW(strFilename.c_str()) != INVALID_FILE_ATTRIBUTES;
 	SetErrorMode(OldMode);
 	return success;
 #endif
@@ -19877,8 +19877,6 @@ int wmain(int argc, wchar_t* argv[])
 	return runFromCommandLine(arguments);
 }
 
-#ifndef _WIN32
-
 int main(int argc, char* argv[])
 {
 	// convert input to wstring
@@ -19901,6 +19899,3 @@ int main(int argc, char* argv[])
 	delete[] wargv;
 	return result;
 }
-
-#endif
-

--- a/tools/assemble_sound.py
+++ b/tools/assemble_sound.py
@@ -66,7 +66,7 @@ def validate(cond, msg, forstr=""):
 
 
 def strip_comments(string):
-    string = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", string)
+    string = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", string)
     return re.sub(re.compile("//.*?\n"), "", string)
 
 

--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -3562,12 +3562,12 @@ struct signConverter
 	static const int kMaxSignedValue = (((1 << (kScaleBits - 1)) - 1) << 1) + 1;
 	static const int kMinSignedValue = -kMaxSignedValue - 1;
 
-	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
+	struct signedToUnsigned : public std::function<UnsignedType(SignedType)>
 	{
 		UnsignedType operator()(SignedType x) { return x - kMinSignedValue; }
 	};
 
-	struct unsignedToSigned : public std::unary_function<SignedType, UnsignedType>
+	struct unsignedToSigned : public std::function<UnsignedType(SignedType)>
 	{
 		SignedType operator()(UnsignedType x) { return x + kMinSignedValue; }
 	};
@@ -3760,7 +3760,7 @@ private:
 };
 
 template <typename Arg, typename Result>
-struct intToFloat : public std::unary_function<Arg, Result>
+struct intToFloat : public std::function<Result(Arg)>
 {
 	Result operator()(Arg x) const { return x; }
 };
@@ -3826,13 +3826,13 @@ private:
 };
 
 template <typename Arg, typename Result, unsigned shift>
-struct lshift : public std::unary_function<Arg, Result>
+struct lshift : public std::function<Result(Arg)>
 {
 	Result operator()(const Arg &x) const { return x << shift; }
 };
 
 template <typename Arg, typename Result, unsigned shift>
-struct rshift : public std::unary_function<Arg, Result>
+struct rshift : public std::function<Result(Arg)>
 {
 	Result operator()(const Arg &x) const { return x >> shift; }
 };
@@ -3928,7 +3928,7 @@ private:
 };
 
 template <typename Arg, typename Result>
-struct floatToFloat : public std::unary_function<Arg, Result>
+struct floatToFloat : public std::function<Result(Arg)>
 {
 	Result operator()(Arg x) const { return x; }
 };

--- a/tools/audiofile/audiofile.cpp
+++ b/tools/audiofile/audiofile.cpp
@@ -3552,6 +3552,17 @@ struct IntTypes<kInt24> { typedef int32_t SignedType; typedef uint32_t UnsignedT
 template <>
 struct IntTypes<kInt32> { typedef int32_t SignedType; typedef uint32_t UnsignedType; };
 
+namespace compat
+{
+	template<typename Arg, typename R>
+	class unary_function
+	{
+	public:
+		using argument_type = Arg;
+		using result_type = R;
+	};
+}
+
 template <FormatCode Format>
 struct signConverter
 {
@@ -3562,12 +3573,12 @@ struct signConverter
 	static const int kMaxSignedValue = (((1 << (kScaleBits - 1)) - 1) << 1) + 1;
 	static const int kMinSignedValue = -kMaxSignedValue - 1;
 
-	struct signedToUnsigned : public std::function<UnsignedType(SignedType)>
+	struct signedToUnsigned : public compat::unary_function<SignedType, UnsignedType>
 	{
 		UnsignedType operator()(SignedType x) { return x - kMinSignedValue; }
 	};
 
-	struct unsignedToSigned : public std::function<UnsignedType(SignedType)>
+	struct unsignedToSigned : public compat::unary_function<SignedType, UnsignedType>
 	{
 		SignedType operator()(UnsignedType x) { return x + kMinSignedValue; }
 	};
@@ -3760,7 +3771,7 @@ private:
 };
 
 template <typename Arg, typename Result>
-struct intToFloat : public std::function<Result(Arg)>
+struct intToFloat : public compat::unary_function<Arg, Result>
 {
 	Result operator()(Arg x) const { return x; }
 };
@@ -3826,13 +3837,13 @@ private:
 };
 
 template <typename Arg, typename Result, unsigned shift>
-struct lshift : public std::function<Result(Arg)>
+struct lshift : public compat::unary_function<Arg, Result>
 {
 	Result operator()(const Arg &x) const { return x << shift; }
 };
 
 template <typename Arg, typename Result, unsigned shift>
-struct rshift : public std::function<Result(Arg)>
+struct rshift : public compat::unary_function<Arg, Result>
 {
 	Result operator()(const Arg &x) const { return x >> shift; }
 };
@@ -3928,7 +3939,7 @@ private:
 };
 
 template <typename Arg, typename Result>
-struct floatToFloat : public std::function<Result(Arg)>
+struct floatToFloat : public compat::unary_function<Arg, Result>
 {
 	Result operator()(Arg x) const { return x; }
 };

--- a/tools/filesizer.c
+++ b/tools/filesizer.c
@@ -1,4 +1,17 @@
-#include <byteswap.h>
+#ifndef _WIN32
+ #include <byteswap.h>
+#else
+#define __bswap_constant_32(x) \
+     ((((x) & 0xff000000u) >> 24) | (((x) & 0x00ff0000u) >>  8) |	      \
+      (((x) & 0x0000ff00u) <<  8) | (((x) & 0x000000ffu) << 24))
+
+static __inline unsigned int
+__bswap_32 (unsigned int __bsx)
+{
+  return __bswap_constant_32 (__bsx);
+}
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/tools/n64graphics.c
+++ b/tools/n64graphics.c
@@ -21,6 +21,7 @@
 #define SCALE_3_8(VAL_) ((VAL_) * 0x24)
 #define SCALE_8_3(VAL_) ((VAL_) / 0x24)
 
+#define bcopy(s1, s2, n) memcpy((s2), (s1), (n))
 
 typedef struct
 {

--- a/tools/sdk-tools/tabledesign/print.c
+++ b/tools/sdk-tools/tabledesign/print.c
@@ -11,10 +11,18 @@ int print_entry(FILE *out, double *row, int order)
     int overflows;
 
     table = malloc(8 * sizeof(double*));
+    if (table == NULL) {
+        fprintf(stderr, "print_entry: could not allocate memory for table\n");
+        exit(1);
+    }
 
     for (i = 0; i < 8; i++)
     {
         table[i] = malloc(order * sizeof(double));
+        if (table[i] == NULL) {
+            fprintf(stderr, "print_entry: could not allocate memory for table[%d]\n", i);
+            exit(1);
+        }
     }
 
     for (i = 0; i < order; i++)

--- a/tools/sdk-tools/tabledesign/tabledesign.h
+++ b/tools/sdk-tools/tabledesign/tabledesign.h
@@ -27,4 +27,8 @@ void refine(double **table, int order, int npredictors, double **data, int dataS
 // print.c
 int print_entry(FILE *out, double *row, int order);
 
+#ifdef EXTRACT_CODEBOOK
+int tabledesign_entry(int, char**);
+#endif
+
 #endif


### PR DESCRIPTION
Most of the changes here are backported from HackerSM64. Also fixes various build warnings.

Builds without warnings on Fedora 44 and Windows 11 via MinGW, ideally should also be checked on Ubuntu via WSL.